### PR TITLE
added generic client but errors

### DIFF
--- a/api-gateway/hertz_server/biz/handler/asset_api/asset_api.go
+++ b/api-gateway/hertz_server/biz/handler/asset_api/asset_api.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 
 	asset_api "api-gateway/hertz_server/biz/model/asset_api"
-	"api-gateway/hertz_server/kitex_gen/asset_management"
-	"api-gateway/hertz_server/kitex_gen/asset_management/assetmanagement"
 
-	clientK "github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/genericclient"
+	"github.com/cloudwego/kitex/pkg/generic"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
+
+// Generic client initialisation
+func NewGenericClient(destServiceName string) genericclient.Client {
+	genericCli := genericclient.NewClient(destServiceName, generic.BinaryThriftGeneric())
+	return genericCli
+}
 
 // QueryStudent .
 // @router asset/query [GET]
@@ -25,84 +30,101 @@ func QueryAsset(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	//add other code here:
-	fmt.Println("Recieved Query Request")
+	// Use generic client
+	// genericclient.NewClient in func NewGenericClient handles all errors
+	client := NewGenericClient()
 
-	//Use Kitex lient to make rpc call
-	client, err := assetmanagement.NewClient("asset", clientK.WithHostPorts("127.0.0.1:8888"))
-	if err != nil {
-		panic(err)
-	}
-
-	reqRpc := &asset_management.QueryAssetRequest{
+	// The resulting reqRpc object represents the request to be
+	// sent to the "QueryAsset" method, with the
+	// asset ID provided as a string value.
+	// It allows the client to specify which asset it wants
+	// to query in the remote "asset" service.
+	requestRpc := &QueryAssetRequest{
 		ID: fmt.Sprintf("%d", req.ID),
 	}
 
-	respRpc, err := client.QueryAsset(ctx, reqRpc)
+	// Responsible for making an RPC Call
+	// to the "QueryAsset" method of the "asset" service
+	// using the Kitex client.
+	responseRpc, err := client.QueryAsset(ctx, requestRpc)
 	if err != nil {
 		panic(err)
 	}
 
-	//RPC call made
-
-	if !respRpc.Exist {
+	if !responseRpc.Exist {
 		resp := &asset_api.QueryAssetResponse{
 			Msg: fmt.Sprintf("No data for asset ID: %d", req.ID),
 		}
-		c.JSON(200, resp)
+		// The response object (resp) is serialized as JSON
+		// using c.JSON(200, resp) and sent as the HTTP response.
+		c.JSON(consts.StatusOK, resp)
 		return
 	}
 
+	// Constructs response for client
+	// A new instance of asset_api.QueryAssetResponse is
+	// created, and its fields ID, Name, and Market are
+	// assigned values from the corresponding fields of
+	// the respRpc response object.
 	resp := &asset_api.QueryAssetResponse{
-		ID:     respRpc.ID,
-		Name:   respRpc.Name,
-		Market: respRpc.Market,
+		ID:     responseRpc.ID.(int),
+		Name:   responseRpc.Name.(string),
+		Market: responseRpc.Market.(string),
 	}
 
 	c.JSON(consts.StatusOK, resp)
 }
 
-// InsertAsset
-// @router asset/insert [POST]
+// InsertAsset is an HTTP handler function for handling the "asset/insert" route with a POST method.
+// It receives an asset_api.InsertAssetRequest object from the client, validates the request,
+// and performs an RPC call to the "InsertAsset" method of the "asset" service using a generic client.
+// The response from the RPC call is converted into an asset_api.InsertAssetResponse object
+// and sent back to the client as an HTTP response.
 func InsertAsset(ctx context.Context, c *app.RequestContext) {
+	// Initialize variables
 	var err error
 	var req asset_api.InsertAssetRequest
+
+	// Bind and validate the request data received from the client
 	err = c.BindAndValidate(&req)
 	if err != nil {
 		c.String(400, err.Error())
 		return
 	}
 
-	fmt.Println("Recieved Insert Request")
+	fmt.Println("Received Insert Request")
 
-	client, err := assetmanagement.NewClient("asset", clientK.WithHostPorts("127.0.0.1:8888"))
-	if err != nil {
-		panic(err)
-	}
+	// Use a generic client to make the RPC call
+	client := NewGenericClient("asset")
 
-	reqRpc := &asset_management.InsertAssetRequest{
+	// Create the request object to be sent to the "InsertAsset" method
+	requestRpc := &InsertAssetRequest{
 		ID:     req.ID,
 		Name:   req.Name,
 		Market: req.Market,
 	}
 
-	respRpc, err := client.InsertAsset(ctx, reqRpc)
+	// Make an RPC call to the "InsertAsset" method using the generic client
+	responseRpc, err := client.InsertAsset(ctx, requestRpc)
 	if err != nil {
 		panic(err)
 	}
 
-	if !respRpc.Ok {
+	// Check if the RPC call was successful
+	if !responseRpc.Ok {
+		// If the response indicates an error, construct the error response
 		resp := asset_api.InsertAssetResponse{
 			OK:  false,
-			Msg: respRpc.Msg,
+			Msg: responseRpc.Msg.(string),
 		}
 		c.JSON(200, resp)
 		return
 	}
 
+	// Construct the successful response
 	resp := asset_api.InsertAssetResponse{
 		OK:  true,
-		Msg: respRpc.Msg,
+		Msg: responseRpc.Msg.(string),
 	}
 
 	c.JSON(200, resp)


### PR DESCRIPTION
Changes : 

1. Updated documentation of code.
2. Tried to add RPC client with generic call feature from hertz but ran into erros

Error info for reference :
`# api-gateway/hertz_server/biz/handler/asset_api`

`biz\handler\asset_api\asset_api.go:18:16: assignment mismatch: 1 variable but genericclient.NewClient returns 2 values`

`biz\handler\asset_api\asset_api.go:35:12: not enough arguments in call to NewGenericClient`

`biz\handler\asset_api\asset_api.go:42:17: undefined: QueryAssetRequest`

`biz\handler\asset_api\asset_api.go:49:29: client.QueryAsset undefined (type genericclient.Client has no field or method QueryAsset)`

`biz\handler\asset_api\asset_api.go:101:17: undefined: InsertAssetRequest`

`biz\handler\asset_api\asset_api.go:108:29: client.InsertAsset undefined (type genericclient.Client has no field or method InsertAsset)`